### PR TITLE
Adds an EndpointMode config option for mixed site instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This will create an API endpoint at the path `/`, and will be anchored to the fi
 For a more advanced implementation, the following configuration shows all the supported options.
 ````csharp 
     HeadRest.ConfigureEndpoint("/api/", "/root//nodeTypeAlias[1]", new HeadRestOptions {
+        Mode = HeadRestEndpointMode.Dedicated,
         ControllerType = typeof(HeadRestController),
         Mapper = ctx => AutoMapper.Map(ctx.Content, ctx.ContentType, ctx.ViewModelType),
         ViewModelMappings = new new HeadRestViewModelMap()
@@ -62,6 +63,9 @@ This will create an endpoint at the url `/api/`, and will be anchored to the nod
 * __rootNodeXPath : string__   
   _[optional, default:"/root/*[@isDoc][1]"]_  
   The XPath statement for the root node from which to anchor your API endpoint to.
+* __Mode : HeadRestEndpointMode__   
+  _[optional, default:HeadRestEndpointMode.Dedicated]_  
+  The mode in which the headrest endpoint will run. Can be either `HeadRestEndpointMode.Dedicated`, in which case the generated endpoint URLs will be the primary URLs for the relevant content nodes, or `HeadRestEndpointMode.Mixed`, in which case node will maintain their primary URLs and the endpoint URLs will be added to the nodes "Other URLs" collection.
 * __ControllerType : Type__   
   _[optional, default:typeof(HeadRestController)]_  
   The Controller to use to service the API requests. Controllers must inherit from `HeadRestController`. Useful to add extra FilterAttributes to the request such as AuthU and the `OAuth` attribute.

--- a/src/Our.Umbraco.HeadRest/HeadRestEndpointMode.cs
+++ b/src/Our.Umbraco.HeadRest/HeadRestEndpointMode.cs
@@ -1,0 +1,8 @@
+﻿namespace Our.Umbraco.HeadRest
+{
+	public enum HeadRestEndpointMode
+	{
+		Dedicated,
+		Mixed
+	}
+}

--- a/src/Our.Umbraco.HeadRest/HeadRestEndpointMode.cs
+++ b/src/Our.Umbraco.HeadRest/HeadRestEndpointMode.cs
@@ -1,8 +1,8 @@
 ﻿namespace Our.Umbraco.HeadRest
 {
-	public enum HeadRestEndpointMode
-	{
-		Dedicated,
-		Mixed
-	}
+    public enum HeadRestEndpointMode
+    {
+        Dedicated,
+        Mixed
+    }
 }

--- a/src/Our.Umbraco.HeadRest/HeadRestOptions.cs
+++ b/src/Our.Umbraco.HeadRest/HeadRestOptions.cs
@@ -6,22 +6,22 @@ using Our.Umbraco.HeadRest.Web.Routing;
 
 namespace Our.Umbraco.HeadRest
 {
-	public class HeadRestOptions : IHeadRestOptions
-	{
-		public HeadRestEndpointMode Mode { get; set; }
-		public Type ControllerType { get; set; }
+    public class HeadRestOptions : IHeadRestOptions
+    {
+        public HeadRestEndpointMode Mode { get; set; }
+        public Type ControllerType { get; set; }
         public Func<HeadRestMappingContext, object> Mapper { get; set; }
         public HeadRestViewModelMap ViewModelMappings { get; set; }
         public HeadRestRouteMap CustomRouteMappings { get; set; }
 
-		public HeadRestOptions()
-		{
-			Mode = HeadRestEndpointMode.Dedicated;
-			ControllerType = typeof(HeadRestController);
+        public HeadRestOptions()
+        {
+            Mode = HeadRestEndpointMode.Dedicated;
+            ControllerType = typeof(HeadRestController);
             Mapper = (ctx) => AutoMapper.Mapper.Map(ctx.Content, ctx.ContentType, ctx.ViewModelType, opts =>
             {
                 opts.Items[HeadRest.MappingContextKey] = ctx;
             });
-		}
+        }
     }
 }

--- a/src/Our.Umbraco.HeadRest/HeadRestOptions.cs
+++ b/src/Our.Umbraco.HeadRest/HeadRestOptions.cs
@@ -6,20 +6,22 @@ using Our.Umbraco.HeadRest.Web.Routing;
 
 namespace Our.Umbraco.HeadRest
 {
-    public class HeadRestOptions : IHeadRestOptions
-    {
-        public Type ControllerType { get; set; }
+	public class HeadRestOptions : IHeadRestOptions
+	{
+		public HeadRestEndpointMode Mode { get; set; }
+		public Type ControllerType { get; set; }
         public Func<HeadRestMappingContext, object> Mapper { get; set; }
         public HeadRestViewModelMap ViewModelMappings { get; set; }
         public HeadRestRouteMap CustomRouteMappings { get; set; }
 
-        public HeadRestOptions()
-        {
-            ControllerType = typeof(HeadRestController);
+		public HeadRestOptions()
+		{
+			Mode = HeadRestEndpointMode.Dedicated;
+			ControllerType = typeof(HeadRestController);
             Mapper = (ctx) => AutoMapper.Mapper.Map(ctx.Content, ctx.ContentType, ctx.ViewModelType, opts =>
             {
                 opts.Items[HeadRest.MappingContextKey] = ctx;
             });
-        }
+		}
     }
 }

--- a/src/Our.Umbraco.HeadRest/Interfaces/IHeadRestOptions.cs
+++ b/src/Our.Umbraco.HeadRest/Interfaces/IHeadRestOptions.cs
@@ -5,11 +5,11 @@ using Our.Umbraco.HeadRest.Web.Routing;
 namespace Our.Umbraco.HeadRest.Interfaces
 {
     public interface IHeadRestOptions
-	{
-		HeadRestEndpointMode Mode { get; }
-		Type ControllerType { get; }
+    {
+        HeadRestEndpointMode Mode { get; }
+        Type ControllerType { get; }
         Func<HeadRestMappingContext, object> Mapper { get; }
         HeadRestViewModelMap ViewModelMappings { get; }
         HeadRestRouteMap CustomRouteMappings { get; }
-	}
+    }
 }

--- a/src/Our.Umbraco.HeadRest/Interfaces/IHeadRestOptions.cs
+++ b/src/Our.Umbraco.HeadRest/Interfaces/IHeadRestOptions.cs
@@ -5,10 +5,11 @@ using Our.Umbraco.HeadRest.Web.Routing;
 namespace Our.Umbraco.HeadRest.Interfaces
 {
     public interface IHeadRestOptions
-    {
-        Type ControllerType { get; }
+	{
+		HeadRestEndpointMode Mode { get; }
+		Type ControllerType { get; }
         Func<HeadRestMappingContext, object> Mapper { get; }
         HeadRestViewModelMap ViewModelMappings { get; }
         HeadRestRouteMap CustomRouteMappings { get; }
-    }
+	}
 }

--- a/src/Our.Umbraco.HeadRest/Our.Umbraco.HeadRest.csproj
+++ b/src/Our.Umbraco.HeadRest/Our.Umbraco.HeadRest.csproj
@@ -211,6 +211,7 @@
   <ItemGroup>
     <Compile Include="Bootstrap.cs" />
     <Compile Include="HeadRestConfig.cs" />
+    <Compile Include="HeadRestEndpointMode.cs" />
     <Compile Include="HeadRestOptions.cs" />
     <Compile Include="Interfaces\IHeadRestConfig.cs" />
     <Compile Include="Interfaces\IHeadRestOptions.cs" />

--- a/src/Our.Umbraco.HeadRest/Web/Routing/HeadRestUrlProvider.cs
+++ b/src/Our.Umbraco.HeadRest/Web/Routing/HeadRestUrlProvider.cs
@@ -2,40 +2,54 @@
 using System.Collections.Generic;
 using System.Linq;
 using Umbraco.Core;
+using Umbraco.Core.Configuration.UmbracoSettings;
 using Umbraco.Web;
 using Umbraco.Web.Routing;
 
 namespace Our.Umbraco.HeadRest.Web.Routing
 {
-    internal class HeadRestUrlProvider : IUrlProvider
-    {
-        public string GetUrl(UmbracoContext umbracoContext, int id, Uri current, UrlProviderMode mode)
+    internal class HeadRestUrlProvider : DefaultUrlProvider
+	{
+		public HeadRestUrlProvider(IRequestHandlerSection requestSettings)
+			: base(requestSettings)
+		{ }
+
+        public override string GetUrl(UmbracoContext umbracoContext, int id, Uri current, UrlProviderMode mode)
         {
-            var content = umbracoContext.ContentCache.GetById(id);
+			var headRestUrl = GetHeadRestUrl(umbracoContext, id, HeadRestEndpointMode.Dedicated);
 
-            foreach(var headRestConfig in HeadRest.Configs.Values)
-            {
-                var rootNode = umbracoContext.ContentCache.GetSingleByXPath(headRestConfig.RootNodeXPath);
-                if (content.Path.StartsWith(rootNode.Path))
-                {
-                    var subUrl = string.Join("/", content.AncestorsOrSelf(true, x => x.Level > rootNode.Level)
-                        .Select(x => x.UrlName)
-                        .Reverse());
-
-                    var url = (headRestConfig.BasePath
-                        .EnsureStartsWith("/")
-                        .EnsureEndsWith("/") + subUrl).EnsureEndsWith('/');
-
-                    return url;
-                }
-            }
-
-            return null;
+			return headRestUrl ?? base.GetUrl(umbracoContext, id, current, mode);
         }
 
-        public IEnumerable<string> GetOtherUrls(UmbracoContext umbracoContext, int id, Uri current)
+        public override IEnumerable<string> GetOtherUrls(UmbracoContext umbracoContext, int id, Uri current)
         {
-            return null;
+			var headRestUrl = GetHeadRestUrl(umbracoContext, id, HeadRestEndpointMode.Mixed);
+
+			return headRestUrl != null ? new[] { headRestUrl } : base.GetOtherUrls(umbracoContext, id, current);
         }
+
+		protected string GetHeadRestUrl(UmbracoContext umbracoContext, int id, HeadRestEndpointMode endpointMode)
+		{
+			var content = umbracoContext.ContentCache.GetById(id);
+
+			foreach (var headRestConfig in HeadRest.Configs.Values.Where(x => x.Mode == endpointMode))
+			{
+				var rootNode = umbracoContext.ContentCache.GetSingleByXPath(headRestConfig.RootNodeXPath);
+				if (content.Path.StartsWith(rootNode.Path))
+				{
+					var subUrl = string.Join("/", content.AncestorsOrSelf(true, x => x.Level > rootNode.Level)
+						.Select(x => x.UrlName)
+						.Reverse());
+
+					var url = (headRestConfig.BasePath
+						.EnsureStartsWith("/")
+						.EnsureEndsWith("/") + subUrl).EnsureEndsWith('/');
+
+					return url;
+				}
+			}
+
+			return null;
+		}
     }
 }

--- a/src/Our.Umbraco.HeadRest/Web/Routing/HeadRestUrlProvider.cs
+++ b/src/Our.Umbraco.HeadRest/Web/Routing/HeadRestUrlProvider.cs
@@ -9,47 +9,47 @@ using Umbraco.Web.Routing;
 namespace Our.Umbraco.HeadRest.Web.Routing
 {
     internal class HeadRestUrlProvider : DefaultUrlProvider
-	{
-		public HeadRestUrlProvider(IRequestHandlerSection requestSettings)
-			: base(requestSettings)
-		{ }
+    {
+        public HeadRestUrlProvider(IRequestHandlerSection requestSettings)
+            : base(requestSettings)
+        { }
 
         public override string GetUrl(UmbracoContext umbracoContext, int id, Uri current, UrlProviderMode mode)
         {
-			var headRestUrl = GetHeadRestUrl(umbracoContext, id, HeadRestEndpointMode.Dedicated);
+            var headRestUrl = GetHeadRestUrl(umbracoContext, id, HeadRestEndpointMode.Dedicated);
 
-			return headRestUrl ?? base.GetUrl(umbracoContext, id, current, mode);
+            return headRestUrl ?? base.GetUrl(umbracoContext, id, current, mode);
         }
 
         public override IEnumerable<string> GetOtherUrls(UmbracoContext umbracoContext, int id, Uri current)
         {
-			var headRestUrl = GetHeadRestUrl(umbracoContext, id, HeadRestEndpointMode.Mixed);
+            var headRestUrl = GetHeadRestUrl(umbracoContext, id, HeadRestEndpointMode.Mixed);
 
-			return headRestUrl != null ? new[] { headRestUrl } : base.GetOtherUrls(umbracoContext, id, current);
+            return headRestUrl != null ? new[] { headRestUrl } : base.GetOtherUrls(umbracoContext, id, current);
         }
 
-		protected string GetHeadRestUrl(UmbracoContext umbracoContext, int id, HeadRestEndpointMode endpointMode)
-		{
-			var content = umbracoContext.ContentCache.GetById(id);
+        protected string GetHeadRestUrl(UmbracoContext umbracoContext, int id, HeadRestEndpointMode endpointMode)
+        {
+            var content = umbracoContext.ContentCache.GetById(id);
 
-			foreach (var headRestConfig in HeadRest.Configs.Values.Where(x => x.Mode == endpointMode))
-			{
-				var rootNode = umbracoContext.ContentCache.GetSingleByXPath(headRestConfig.RootNodeXPath);
-				if (content.Path.StartsWith(rootNode.Path))
-				{
-					var subUrl = string.Join("/", content.AncestorsOrSelf(true, x => x.Level > rootNode.Level)
-						.Select(x => x.UrlName)
-						.Reverse());
+            foreach (var headRestConfig in HeadRest.Configs.Values.Where(x => x.Mode == endpointMode))
+            {
+                var rootNode = umbracoContext.ContentCache.GetSingleByXPath(headRestConfig.RootNodeXPath);
+                if (content.Path.StartsWith(rootNode.Path))
+                {
+                    var subUrl = string.Join("/", content.AncestorsOrSelf(true, x => x.Level > rootNode.Level)
+                        .Select(x => x.UrlName)
+                        .Reverse());
 
-					var url = (headRestConfig.BasePath
-						.EnsureStartsWith("/")
-						.EnsureEndsWith("/") + subUrl).EnsureEndsWith('/');
+                    var url = (headRestConfig.BasePath
+                        .EnsureStartsWith("/")
+                        .EnsureEndsWith("/") + subUrl).EnsureEndsWith('/');
 
-					return url;
-				}
-			}
+                    return url;
+                }
+            }
 
-			return null;
-		}
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Potential fix for issue #4. Adds a config option to define whether the endpoint is dedicated or mixed. Depending on the option chosen, the endpoint URL's will either be the nodes primary URL if Dedicated or part of the nodes "Other Urls" collection if Mixed.