### PR TITLE
Removed double new keywords in some examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ From within the `Initialize` method, you can then configure your endpoint(s) via
 For the most basic implementation, the following minimal configuration is all that is needed:
 ````csharp 
     _headRest.ConfigureEndpoint(new HeadRestOptions {
-        ViewModelMappings = new new HeadRestViewModelMap()
+        ViewModelMappings = new HeadRestViewModelMap()
             .For(HomePage.ModelTypeAlias).MapTo<HomePageViewModel>()
             ...
     });
@@ -61,7 +61,7 @@ For a more advanced implementation, the following configuration shows all the su
         Mode = HeadRestEndpointMode.Dedicated,
         ControllerType = typeof(HeadRestController),
         Mapper = ctx => AutoMapper.Map(ctx.Content, ctx.ContentType, ctx.ViewModelType),
-        ViewModelMappings = new new HeadRestViewModelMap()
+        ViewModelMappings = new HeadRestViewModelMap()
             .For(HomePage.ModelTypeAlias)
                 .If(x => x.Request.HeadRestRouteParam("altRoute") == "init")
                 .MapTo<InitViewModel>()


### PR DESCRIPTION
I found some small typos/double keywords in the examples when I copied them. Decided to submit/fix it. Cheers!